### PR TITLE
lib: Removed transactions_of_us element from status

### DIFF
--- a/naruno/lib/status.py
+++ b/naruno/lib/status.py
@@ -57,8 +57,7 @@ def Status(
 
         transactions = (GetMyTransaction() if custom_transactions is None else
                         custom_transactions)
-        transactions_of_us = str(
-            [f"{str(i[0].dump_json())} | {str(i[1])}" for i in transactions])
+
 
         last_transaction_of_block = (
             str(new_block.validating_list[-1].dump_json())
@@ -69,7 +68,6 @@ def Status(
             "first_block": str(first_block.dump_json()),
             "new_block": str(new_block.dump_json()),
             "last_transaction_of_block": last_transaction_of_block,
-            "transactions_of_us": transactions_of_us,
             "connected_nodes": connected_nodes,
         }
 

--- a/tests/unit_tests/test_api.py
+++ b/tests/unit_tests/test_api.py
@@ -684,13 +684,7 @@ class Test_API(unittest.TestCase):
         self.assertEqual(result["status"], "Working")
         self.assertEqual(result["last_transaction_of_block"],
                          str(the_transaction.dump_json()))
-        self.assertEqual(
-            result["transactions_of_us"],
-            str([
-                f"{str(i[0].__dict__)} | {str(i[1])}"
-                for i in custom_transactions
-            ]),
-        )
+
         save_settings(backup_settings)
 
     def test_404_page(self):

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -358,13 +358,7 @@ class Test_Lib(unittest.TestCase):
         self.assertEqual(result["status"], "Not working")
         self.assertEqual(result["last_transaction_of_block"],
                          str(the_transaction.dump_json()))
-        self.assertEqual(
-            result["transactions_of_us"],
-            str([
-                f"{str(i[0].__dict__)} | {str(i[1])}"
-                for i in custom_transactions
-            ]),
-        )
+
         self.assertEqual(result["connected_nodes"],
                          ["127.0.0.1:10001", "127.0.0.1:10002"])
 
@@ -399,13 +393,7 @@ class Test_Lib(unittest.TestCase):
         self.assertEqual(result["status"], "Working")
         self.assertEqual(result["last_transaction_of_block"],
                          str(the_transaction.dump_json()))
-        self.assertEqual(
-            result["transactions_of_us"],
-            str([
-                f"{str(i[0].__dict__)} | {str(i[1])}"
-                for i in custom_transactions
-            ]),
-        )
+
         self.assertEqual(result["connected_nodes"],
                          ["127.0.0.1:10001", "127.0.0.1:10002"])
 
@@ -440,13 +428,7 @@ class Test_Lib(unittest.TestCase):
         self.assertEqual(result["status"], "Working")
         self.assertEqual(result["last_transaction_of_block"],
                          str(the_transaction.dump_json()))
-        self.assertEqual(
-            result["transactions_of_us"],
-            str([
-                f"{str(i[0].__dict__)} | {str(i[1])}"
-                for i in custom_transactions
-            ]),
-        )
+
         self.assertEqual(result["connected_nodes"],
                          ["127.0.0.1:10001", "127.0.0.1:10002"])
 
@@ -485,13 +467,7 @@ class Test_Lib(unittest.TestCase):
         self.assertEqual(result["status"], "Working")
         self.assertEqual(result["last_transaction_of_block"],
                          str(the_transaction.dump_json()))
-        self.assertEqual(
-            result["transactions_of_us"],
-            str([
-                f"{str(i[0].__dict__)} | {str(i[1])}"
-                for i in custom_transactions
-            ]),
-        )
+
         self.assertEqual(result["connected_nodes"],
                          ["127.0.0.1:10001", "127.0.0.1:10002"])
 
@@ -506,13 +482,7 @@ class Test_Lib(unittest.TestCase):
         self.assertEqual(result["status"], "Working")
         self.assertEqual(result["last_transaction_of_block"],
                          str(the_transaction.dump_json()))
-        self.assertEqual(
-            result["transactions_of_us"],
-            str([
-                f"{str(i[0].__dict__)} | {str(i[1])}"
-                for i in custom_transactions
-            ]),
-        )
+
         self.assertEqual(result["connected_nodes"],
                          ["127.0.0.1:10001", "127.0.0.1:10002"])
 
@@ -553,13 +523,7 @@ class Test_Lib(unittest.TestCase):
         self.assertEqual(result["status"], "Working")
         self.assertEqual(result["last_transaction_of_block"],
                          str(the_transaction.dump_json()))
-        self.assertEqual(
-            result["transactions_of_us"],
-            str([
-                f"{str(i[0].__dict__)} | {str(i[1])}"
-                for i in custom_transactions
-            ]),
-        )
+
         self.assertEqual(result["connected_nodes"],
                          ["127.0.0.1:10001", "127.0.0.1:10002"])
         time.sleep(5)
@@ -609,13 +573,7 @@ class Test_Lib(unittest.TestCase):
         self.assertEqual(result["status"], "Working")
         self.assertEqual(result["last_transaction_of_block"],
                          str(the_transaction.dump_json()))
-        self.assertEqual(
-            result["transactions_of_us"],
-            str([
-                f"{str(i[0].__dict__)} | {str(i[1])}"
-                for i in custom_transactions
-            ]),
-        )
+
         self.assertEqual(result["connected_nodes"],
                          ["127.0.0.1:10001", "127.0.0.1:10002"])
         time.sleep(10)
@@ -634,13 +592,7 @@ class Test_Lib(unittest.TestCase):
         self.assertEqual(result["status"], "Working")
         self.assertEqual(result["last_transaction_of_block"],
                          str(the_transaction.dump_json()))
-        self.assertEqual(
-            result["transactions_of_us"],
-            str([
-                f"{str(i[0].__dict__)} | {str(i[1])}"
-                for i in custom_transactions
-            ]),
-        )
+
         self.assertEqual(result["connected_nodes"],
                          ["127.0.0.1:10001", "127.0.0.1:10002"])
         save_settings(backup_settings)
@@ -680,13 +632,7 @@ class Test_Lib(unittest.TestCase):
         self.assertEqual(result["status"], "Working")
         self.assertEqual(result["last_transaction_of_block"],
                          str(the_transaction.dump_json()))
-        self.assertEqual(
-            result["transactions_of_us"],
-            str([
-                f"{str(i[0].__dict__)} | {str(i[1])}"
-                for i in custom_transactions
-            ]),
-        )
+
         self.assertEqual(result["connected_nodes"],
                          ["127.0.0.1:10001", "127.0.0.1:10002"])
         time.sleep(9)


### PR DESCRIPTION
## Why ? 

I am sending this pr because... (If you send for an issue please use "Closes #issuenumber" for here.)

## Checking
- [ ] No personal details (pass and etc.)
