### PR TITLE
github: Added a concurrency group value for dividing releases from pushes

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -22,7 +22,7 @@ on:
       - 'tests/**'
       - 'auto_builders/**'      
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
   run:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ on:
     - cron: '22 14 * * 5'
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
   analyze:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
   dependency-review:

--- a/.github/workflows/deploys.yml
+++ b/.github/workflows/deploys.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
   deploy-pypi:

--- a/.github/workflows/docker_stability_test_10_3.yml
+++ b/.github/workflows/docker_stability_test_10_3.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/docker_stability_test_3_1.yml
+++ b/.github/workflows/docker_stability_test_3_1.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/docker_stability_test_4_1.yml
+++ b/.github/workflows/docker_stability_test_4_1.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/docker_stability_test_5_1.yml
+++ b/.github/workflows/docker_stability_test_5_1.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/docker_stability_test_5_2.yml
+++ b/.github/workflows/docker_stability_test_5_2.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/docker_stability_test_6_1.yml
+++ b/.github/workflows/docker_stability_test_6_1.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/docker_stability_test_6_2.yml
+++ b/.github/workflows/docker_stability_test_6_2.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/docker_stability_test_7_1.yml
+++ b/.github/workflows/docker_stability_test_7_1.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/docker_stability_test_7_2.yml
+++ b/.github/workflows/docker_stability_test_7_2.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/docs_videos.yml
+++ b/.github/workflows/docs_videos.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/gource.yml
+++ b/.github/workflows/gource.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
   gource:

--- a/.github/workflows/labeler_pull_requests.yml
+++ b/.github/workflows/labeler_pull_requests.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, edited]
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/local_stability_test_10_3.yml
+++ b/.github/workflows/local_stability_test_10_3.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/local_stability_test_3_1.yml
+++ b/.github/workflows/local_stability_test_3_1.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/local_stability_test_4_1.yml
+++ b/.github/workflows/local_stability_test_4_1.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/local_stability_test_5_1.yml
+++ b/.github/workflows/local_stability_test_5_1.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/local_stability_test_5_2.yml
+++ b/.github/workflows/local_stability_test_5_2.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/local_stability_test_6_1.yml
+++ b/.github/workflows/local_stability_test_6_1.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/local_stability_test_6_2.yml
+++ b/.github/workflows/local_stability_test_6_2.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/local_stability_test_7_1.yml
+++ b/.github/workflows/local_stability_test_7_1.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/local_stability_test_7_2.yml
+++ b/.github/workflows/local_stability_test_7_2.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
 

--- a/.github/workflows/ossar.yml
+++ b/.github/workflows/ossar.yml
@@ -32,7 +32,7 @@ permissions:
   contents: read
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
   OSSAR-Scan:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event }}
   cancel-in-progress: true
 jobs:
   lint_with_flake8:


### PR DESCRIPTION
## Why ? 

Closes #1069 

## Checking
- [x] No personal details (pass and etc.)
